### PR TITLE
Render mermaid fenced blocks as diagrams in HTML report

### DIFF
--- a/internal/specdown/reporter/html/assets/script.js
+++ b/internal/specdown/reporter/html/assets/script.js
@@ -82,3 +82,23 @@
   window.addEventListener('resize', schedule);
   update();
 })();
+
+// Mermaid: progressive enhancement — load from CDN only when diagrams are present.
+// Pinned to an exact release; update the integrity hash when bumping the version.
+(() => {
+  if (!document.querySelector('pre.mermaid')) return;
+  const s = document.createElement('script');
+  s.src = 'https://unpkg.com/mermaid@11.4.1/dist/mermaid.min.js';
+  s.integrity = 'sha384-rbtjAdnIQE/aQJGEgXrVUlMibdfTSa4PQju4HDhN3sR2PmaKFzhEafuePsl9H/9I';
+  s.crossOrigin = 'anonymous';
+  s.onload = () => {
+    mermaid.initialize({ startOnLoad: false, theme: 'neutral' });
+    mermaid.run({ querySelector: 'pre.mermaid' });
+  };
+  s.onerror = () => {
+    document.querySelectorAll('pre.mermaid').forEach((el) => {
+      el.title = 'Mermaid diagram — requires internet connection to render';
+    });
+  };
+  document.head.appendChild(s);
+})();

--- a/internal/specdown/reporter/html/assets/style.css
+++ b/internal/specdown/reporter/html/assets/style.css
@@ -867,6 +867,28 @@ code, pre, kbd, samp {
   margin: 0.5rem 0 1.5rem;
 }
 
+/* ── Mermaid diagrams ── */
+.mermaid-diagram {
+  margin: 1.25rem 0;
+  overflow-x: auto;
+}
+.mermaid-diagram pre.mermaid {
+  /* Fallback: raw source shown as readable code until JS renders SVG */
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  color: var(--muted);
+  background: var(--note-bg);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  padding: 1rem;
+  white-space: pre;
+}
+.mermaid-diagram svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
 /* ── Trace tag (type badge) ── */
 .trace-tag {
   display: inline-block;

--- a/internal/specdown/reporter/html/render.go
+++ b/internal/specdown/reporter/html/render.go
@@ -112,6 +112,9 @@ func renderNode(node core.Node, caseResults map[string]core.CaseResult) (string,
 
 func renderCodeBlock(node core.CodeBlockNode, caseResults map[string]core.CaseResult) (string, error) {
 	if node.ID == nil {
+		if fields := strings.Fields(node.Block.Raw); len(fields) > 0 && fields[0] == "mermaid" {
+			return renderMermaidBlock(node), nil
+		}
 		return markdownToHTML(node.Markdown())
 	}
 
@@ -171,6 +174,16 @@ func renderCodeBlock(node core.CodeBlockNode, caseResults map[string]core.CaseRe
 	out.WriteString(`</p>`)
 	out.WriteString(`</section>`)
 	return out.String(), nil
+}
+
+func renderMermaidBlock(node core.CodeBlockNode) string {
+	var out strings.Builder
+	out.WriteString(`<div class="mermaid-diagram">`)
+	out.WriteString(`<pre class="mermaid">`)
+	out.WriteString(template.HTMLEscapeString(node.Source))
+	out.WriteString(`</pre>`)
+	out.WriteString(`</div>`)
+	return out.String()
 }
 
 func renderCodeSource(out *strings.Builder, result core.CaseResult) {

--- a/internal/specdown/reporter/html/reporter_test.go
+++ b/internal/specdown/reporter/html/reporter_test.go
@@ -965,3 +965,91 @@ func TestWriteDocTypeBadgeInTOC(t *testing.T) {
 	assertContains(t, html, `toc-type-badge`, "type badge in TOC")
 	assertContains(t, html, `>spec</span>`, "type value in badge")
 }
+
+func TestWriteRendersMermaidBlock(t *testing.T) {
+	mermaidSource := "graph LR\n    A[Core] --> B[Adapter]"
+	report := core.Report{
+		GeneratedAt: time.Date(2026, 3, 6, 1, 2, 3, 0, time.UTC),
+		Summary:     core.Summary{SpecsTotal: 1, SpecsPassed: 1},
+		Results: []core.DocumentResult{
+			{
+				Status: core.StatusPassed,
+				Document: core.Document{
+					Title:      "Diagram Test",
+					RelativeTo: "specs/diagram.spec.md",
+					Nodes: []core.Node{
+						core.HeadingNode{Level: 1, Text: "Diagram Test", Raw: "# Diagram Test\n", HeadingPath: []string{"Diagram Test"}},
+						// Standard mermaid block — no ID means non-executable.
+						core.CodeBlockNode{
+							Block:  core.BlockSpec{Raw: "mermaid"},
+							Source: mermaidSource,
+							Raw:    "```mermaid\n" + mermaidSource + "\n```\n",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	html := writeAndReadReport(t, report)
+
+	t.Run("renders_mermaid_container", func(t *testing.T) {
+		assertContains(t, html, `class="mermaid-diagram"`, "mermaid wrapper div")
+		assertContains(t, html, `<pre class="mermaid">`, "mermaid pre element")
+	})
+
+	t.Run("source_is_html_escaped", func(t *testing.T) {
+		// Source with HTML special chars must be escaped, not injected raw.
+		xssReport := core.Report{
+			GeneratedAt: time.Date(2026, 3, 6, 1, 2, 3, 0, time.UTC),
+			Summary:     core.Summary{SpecsTotal: 1, SpecsPassed: 1},
+			Results: []core.DocumentResult{
+				{
+					Status: core.StatusPassed,
+					Document: core.Document{
+						Title:      "XSS Test",
+						RelativeTo: "specs/xss.spec.md",
+						Nodes: []core.Node{
+							core.HeadingNode{Level: 1, Text: "XSS Test", Raw: "# XSS Test\n", HeadingPath: []string{"XSS Test"}},
+							core.CodeBlockNode{
+								Block:  core.BlockSpec{Raw: "mermaid"},
+								Source: `graph LR\n    A --> B["<script>alert(1)</script>"]`,
+								Raw:    "```mermaid\n...\n```\n",
+							},
+						},
+					},
+				},
+			},
+		}
+		xssHTML := writeAndReadReport(t, xssReport)
+		assertNotContains(t, xssHTML, "<script>alert(1)</script>", "raw script tag must not appear unescaped")
+		assertContains(t, xssHTML, "&lt;script&gt;", "script tag must be HTML-escaped")
+	})
+
+	t.Run("capitalised_mermaid_does_not_match", func(t *testing.T) {
+		// Detection is case-sensitive: "Mermaid" should fall through to normal code rendering.
+		capsReport := core.Report{
+			GeneratedAt: time.Date(2026, 3, 6, 1, 2, 3, 0, time.UTC),
+			Summary:     core.Summary{SpecsTotal: 1, SpecsPassed: 1},
+			Results: []core.DocumentResult{
+				{
+					Status: core.StatusPassed,
+					Document: core.Document{
+						Title:      "Caps Test",
+						RelativeTo: "specs/caps.spec.md",
+						Nodes: []core.Node{
+							core.HeadingNode{Level: 1, Text: "Caps Test", Raw: "# Caps Test\n", HeadingPath: []string{"Caps Test"}},
+							core.CodeBlockNode{
+								Block:  core.BlockSpec{Raw: "Mermaid"},
+								Source: "graph LR",
+								Raw:    "```Mermaid\ngraph LR\n```\n",
+							},
+						},
+					},
+				},
+			},
+		}
+		capsHTML := writeAndReadReport(t, capsReport)
+		assertNotContains(t, capsHTML, `class="mermaid-diagram"`, "capitalised Mermaid must not match")
+	})
+}


### PR DESCRIPTION
## Summary

- Render `mermaid` fenced code blocks as interactive diagrams in the HTML report
- Loads Mermaid JS (v11.4.1) from unpkg CDN with SRI integrity check and `crossOrigin` attribute
- Falls back gracefully: if CDN is unreachable, diagram elements show a tooltip instead of broken content
- Detection is robust: matches `mermaid` as the first token of the info string (handles extra attributes)

## Details

- `render.go`: detects mermaid blocks (no `ID`) and emits `<pre class="mermaid">` wrapped in `<div class="mermaid-diagram">`
- `script.js`: dynamically injects CDN script, calls `mermaid.initialize` + `mermaid.run` on load
- `style.css`: styles the container and SVG output; shows raw source as styled pre-block until JS renders it
- `reporter_test.go`: unit tests for container rendering, HTML escaping, and case-sensitivity

Closes corca-ai/specdown#11

---

## 요약

- HTML 리포트에서 `mermaid` 코드 블록을 다이어그램으로 렌더링합니다
- unpkg CDN에서 Mermaid JS(v11.4.1)를 로드하며, SRI 무결성 검증 및 `crossOrigin` 속성 적용
- CDN 접근 불가 시 다이어그램 요소에 툴팁을 표시하는 방식으로 graceful fallback 처리
- info string의 첫 번째 토큰이 `mermaid`인지 확인하는 방식으로 안정적인 감지

## 변경 내용

- `render.go`: mermaid 블록 감지 후 `<pre class="mermaid">`를 `<div class="mermaid-diagram">`으로 감쌈
- `script.js`: CDN 스크립트를 동적으로 주입하고, 로드 완료 시 `mermaid.initialize` + `mermaid.run` 호출
- `style.css`: 컨테이너 및 SVG 스타일링 / JS 렌더링 전까지 소스를 pre 블록으로 표시
- `reporter_test.go`: 컨테이너 렌더링, HTML 이스케이프, 대소문자 구분 관련 유닛 테스트 추가

Closes corca-ai/specdown#11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* Mermaid 다이어그램 지원이 추가되었습니다.
* CDN을 통한 자동 다이어그램 렌더링이 지원됩니다.
* 반응형 다이어그램 스타일링으로 모든 화면 크기에 최적화됩니다.
* 인터넷 연결 없을 시 다이어그램 소스 코드가 표시됩니다.

## 테스트

* Mermaid 다이어그램 렌더링 검증 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->